### PR TITLE
Support for ATmega4809 (Arduino Uno Wifi Rev2, Arduino Nano Every)

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Arduino library to send and receive data from Opentherm devices.
 paragraph=Using this library and special hardware interface you will be able to create your own thermostat to control Opentherm boiler or build a man-in-the-middle gateway to capture or alter communication running between your thermostat and boiler. For detailed information go to https://github.com/jpraus/arduino-opentherm.
 category=Communication
 url=https://github.com/jpraus/arduino-opentherm
-architectures=avr,esp8266
+architectures=avr,esp8266,megaavr
 includes=opentherm.h

--- a/src/opentherm.cpp
+++ b/src/opentherm.cpp
@@ -228,7 +228,7 @@ void OPENTHERM::_callCallback() {
   }
 }
 
-#ifdef AVR
+#if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega168__) // Arduino Uno
 ISR(TIMER2_COMPA_vect) { // Timer2 interrupt
   OPENTHERM::_timerISR();
 }
@@ -280,7 +280,51 @@ void OPENTHERM::_stopTimer() {
   TIMSK2 = 0;
   sei();
 }
-#endif // END AVR
+#endif // END AVR arduino Uno
+
+#if defined(__AVR_ATmega4809__) // Arduino Uno Wifi Rev2, Arduino Nano Every
+// timer interrupt
+ISR(TCB0_INT_vect) {
+  OPENTHERM::_timerISR();
+  TCB0.INTFLAGS = TCB_CAPT_bm; // clear interrupt flag
+}
+
+// 5 kHz timer
+void OPENTHERM::_startReadTimer() {
+  cli();
+  TCB0.CTRLB = TCB_CNTMODE_INT_gc; // use timer compare mode
+  TCB0.CCMP = 3199; // value to compare with (16*10^6) / 5000 - 1
+  TCB0.INTCTRL = TCB_CAPT_bm; // enable the interrupt
+  TCB0.CTRLA = TCB_CLKSEL_CLKDIV1_gc | TCB_ENABLE_bm; // use Timer A as clock, enable timer
+  sei();
+}
+
+// 2 kHz timer
+void OPENTHERM::_startWriteTimer() {
+  cli();
+  TCB0.CTRLB = TCB_CNTMODE_INT_gc; // use timer compare mode
+  TCB0.CCMP = 7999; // value to compare with (16*10^6) / 2000 - 1
+  TCB0.INTCTRL = TCB_CAPT_bm; // enable the interrupt
+  TCB0.CTRLA = TCB_CLKSEL_CLKDIV1_gc | TCB_ENABLE_bm; // use Timer A as clock, enable timer
+  sei();
+}
+
+// 1 kHz timer
+void OPENTHERM::_startTimeoutTimer() {
+  cli();
+  TCB0.CTRLB = TCB_CNTMODE_INT_gc; // use timer compare mode
+  TCB0.CCMP = 15999; // value to compare with (16*10^6) / 1000 - 1
+  TCB0.INTCTRL = TCB_CAPT_bm; // enable the interrupt
+  TCB0.CTRLA = TCB_CLKSEL_CLKDIV1_gc | TCB_ENABLE_bm; // use Timer A as clock, enable timer
+  sei();
+}
+
+void OPENTHERM::_stopTimer() {
+  cli();
+  TCB0.CTRLA = 0;
+  sei();
+}
+#endif // END ATMega4809 Arduino Uno Wifi Rev2, Arduino Nano Every
 
 #ifdef ESP8266
 // 5 kHz timer


### PR DESCRIPTION
Here is a patch that makes the library work with the Arduino Uno Wifi Rev2 which has an ATmega4809 microcontroller.

Documentation found here: [TB3214-Getting-Started-with-TCB-90003214A.pdf](http://ww1.microchip.com/downloads/en/Appnotes/TB3214-Getting-Started-with-TCB-90003214A.pdf)

Thanks!