### PR TITLE
Add missing message ids

### DIFF
--- a/src/opentherm.h
+++ b/src/opentherm.h
@@ -21,8 +21,14 @@
 #define OT_MSGID_FAULT_FLAGS          5
 #define OT_MSGID_REMOTE               6
 #define OT_MSGID_COOLING_CONTROL      7
-#define OT_MSGID_CONTROL_SETPOINT_CH2 8
+#define OT_MSGID_CH2_SETPOINT         8
 #define OT_MSGID_CH_SETPOINT_OVERRIDE 9
+#define OT_MSGID_TSP_COUNT            10
+#define OT_MSGID_TSP_COMMAND          11
+#define OT_MSGID_FHB_SIZE             12
+#define OT_MSGID_FHB_COMMAND          13
+#define OT_MSGID_MAX_MODULATION_LEVEL 14
+#define OT_MSGID_MAX_BOILER_CAPACITY  15
 #define OT_MSGID_ROOM_SETPOINT        16
 #define OT_MSGID_MODULATION_LEVEL     17
 #define OT_MSGID_CH_WATER_PRESSURE    18
@@ -43,8 +49,10 @@
 #define OT_MSGID_EXHAUST_TEMP         33
 #define OT_MSGID_DHW_BOUNDS           48
 #define OT_MSGID_CH_BOUNDS            49
+#define OT_MSGID_OTC_CURVE_BOUNDS     50
 #define OT_MSGID_DHW_SETPOINT         56
 #define OT_MSGID_MAX_CH_SETPOINT      57
+#define OT_MSGID_OTC_CURVE_RATIO      58
 
 // HVAC Specific Message IDs
 #define OT_MSGID_HVAC_STATUS          70
@@ -59,6 +67,7 @@
 #define OT_MSGID_NOM_REL_VENTILATION  87
 
 #define OT_MSGID_OVERRIDE_FUNC        100
+#define OT_MSGID_OEM_DIAGNOSTIC       115
 #define OT_MSGID_BURNER_STARTS        116
 #define OT_MSGID_CH_PUMP_STARTS       117
 #define OT_MSGID_DHW_PUMP_STARTS      118


### PR DESCRIPTION
Even though no one will probably use them I think it's better to have them here for gateway listening purposes


Messages 50 and 58 have no data documentation and are only mentioned in message list summary
Renamed message 8 from `OT_MSGID_CONTROL_SETPOINT_CH2` to `OT_MSGID_CH2_SETPOINT` because of `OT_MSGID_CH_SETPOINT` (names should be the same as the messages do the same)