### PR TITLE
Save memory. Store Serial strings to flash.

### DIFF
--- a/examples/gateway/gateway.ino
+++ b/examples/gateway/gateway.ino
@@ -55,7 +55,7 @@ void loop() {
       OPENTHERM::listen(THERMOSTAT_IN);
     }
     else if (OPENTHERM::getMessage(message)) {
-      Serial.print("-> ");
+      Serial.print(F("-> "));
       OPENTHERM::printToSerial(message);
       Serial.println();
       OPENTHERM::send(BOILER_OUT, message); // forward message to boiler
@@ -67,7 +67,7 @@ void loop() {
       OPENTHERM::listen(BOILER_IN, 800); // response need to be send back by boiler within 800ms
     }
     else if (OPENTHERM::getMessage(message)) {
-      Serial.print("<- ");
+      Serial.print(F("<- "));
       OPENTHERM::printToSerial(message);
       Serial.println();
       Serial.println();
@@ -76,7 +76,7 @@ void loop() {
     }
     else if (OPENTHERM::isError()) {
       mode = MODE_LISTEN_MASTER;
-      Serial.println("<- Timeout");
+      Serial.println(F("<- Timeout"));
       Serial.println();
     }
   }

--- a/examples/master/master.ino
+++ b/examples/master/master.ino
@@ -37,7 +37,7 @@ void loop() {
     message.id = OT_MSGID_SLAVE_CONFIG;
     message.valueHB = 0;
     message.valueLB = 0;
-    Serial.print("-> "); 
+    Serial.print(F("-> ")); 
     OPENTHERM::printToSerial(message); 
     Serial.println();
     OPENTHERM::send(BOILER_OUT, message); // send message to boiler
@@ -47,7 +47,7 @@ void loop() {
   }
   else if (OPENTHERM::getMessage(message)) { // boiler responded
     OPENTHERM::stop();
-    Serial.print("<- ");
+    Serial.print(F("<- "));
     OPENTHERM::printToSerial(message);
     Serial.println();
     Serial.println();
@@ -55,7 +55,7 @@ void loop() {
   }
   else if (OPENTHERM::isError()) {
     OPENTHERM::stop();
-    Serial.println("<- Timeout");
+    Serial.println(F("<- Timeout"));
     Serial.println();
   }
 }

--- a/examples/selftest/selftest.ino
+++ b/examples/selftest/selftest.ino
@@ -29,7 +29,7 @@ void setup() {
   Serial.begin(115200);
   delay(1000);
 
-  Serial.println("OpenTherm gateway self-test");
+  Serial.println(F("OpenTherm gateway self-test"));
 }
 
 /**
@@ -43,21 +43,21 @@ void loop() {
 /*
   digitalWrite(BOILER_OUT, HIGH);
   delay(10);
-  Serial.print("H => ");
+  Serial.print(F("H => "));
   Serial.println(digitalRead(THERMOSTAT_IN));
 
   delay(1000);
 
   digitalWrite(BOILER_OUT, LOW);
   delay(10);
-  Serial.print("L => ");
+  Serial.print(F("L => "));
   Serial.println(digitalRead(THERMOSTAT_IN));
   
 
   delay(1000);
   return;
 */
-  Serial.print("Boiler inbound, thermostat outbound .. ");
+  Serial.print(F("Boiler inbound, thermostat outbound .. "));
   digitalWrite(THERMOSTAT_OUT, HIGH);
   digitalWrite(BOILER_OUT, HIGH);
   delay(10);
@@ -68,19 +68,19 @@ void loop() {
     delay(10);
 
     if (digitalRead(THERMOSTAT_IN) == 0 && digitalRead(BOILER_IN) == 1) { // ok
-      Serial.println("OK");
+      Serial.println(F("OK"));
     }
     else {
-      Serial.println("Failed");
-      Serial.println("Boiler is not registering signal or thermostat is not sending properly");
+      Serial.println(F("Failed"));
+      Serial.println(F("Boiler is not registering signal or thermostat is not sending properly"));
     }
   }
   else {
-    Serial.println("Failed");
-    Serial.println("Boiler is high even if no signal is being sent");
+    Serial.println(F("Failed"));
+    Serial.println(F("Boiler is high even if no signal is being sent"));
   }
   
-  Serial.print("Boiler outbound, thermostat inbound .. ");
+  Serial.print(F("Boiler outbound, thermostat inbound .. "));
   digitalWrite(THERMOSTAT_OUT, HIGH);
   digitalWrite(BOILER_OUT, HIGH);
   delay(10);
@@ -91,16 +91,16 @@ void loop() {
     delay(10);
 
     if (digitalRead(THERMOSTAT_IN) == 1 && digitalRead(BOILER_IN) == 0) { // ok
-      Serial.println("OK");
+      Serial.println(F("OK"));
     }
     else {
-      Serial.println("Failed");
-      Serial.println("Thermostat is not registering signal or boiler is not sending properly");
+      Serial.println(F("Failed"));
+      Serial.println(F("Thermostat is not registering signal or boiler is not sending properly"));
     }
   }
   else {
-    Serial.println("Failed");
-    Serial.println("Thermostat is high even if no signal is being sent");
+    Serial.println(F("Failed"));
+    Serial.println(F("Thermostat is high even if no signal is being sent"));
   }
 
   delay(1000);

--- a/examples/slave/slave.ino
+++ b/examples/slave/slave.ino
@@ -33,7 +33,7 @@ void setup() {
  */
 void loop() {
   if (OPENTHERM::getMessage(message)) {
-    Serial.print("-> ");
+    Serial.print(F("-> "));
     OPENTHERM::printToSerial(message);
     Serial.println();
     delay(100); // Opentherm defines delay between request and response
@@ -48,7 +48,7 @@ void loop() {
 }
 
 void listenAfterResponse() {
-  Serial.print("<- ");
+  Serial.print(F("<- "));
   OPENTHERM::printToSerial(message);
   Serial.println();
   Serial.println();

--- a/src/opentherm.cpp
+++ b/src/opentherm.cpp
@@ -477,34 +477,34 @@ bool OPENTHERM::_checkParity(unsigned long val) {
 
 void OPENTHERM::printToSerial(OpenthermData &data) {
   if (data.type == OT_MSGTYPE_READ_DATA) {
-    Serial.print("ReadData");
+    Serial.print(F("ReadData"));
   }
   else if (data.type == OT_MSGTYPE_READ_ACK) {
-    Serial.print("ReadAck");
+    Serial.print(F("ReadAck"));
   }
   else if (data.type == OT_MSGTYPE_WRITE_DATA) {
-    Serial.print("WriteData");
+    Serial.print(F("WriteData"));
   }
   else if (data.type == OT_MSGTYPE_WRITE_ACK) {
-    Serial.print("WriteAck");
+    Serial.print(F("WriteAck"));
   }
   else if (data.type == OT_MSGTYPE_INVALID_DATA) {
-    Serial.print("InvalidData");
+    Serial.print(F("InvalidData"));
   }
   else if (data.type == OT_MSGTYPE_DATA_INVALID) {
-    Serial.print("DataInvalid");
+    Serial.print(F("DataInvalid"));
   }
   else if (data.type == OT_MSGTYPE_UNKNOWN_DATAID) {
-    Serial.print("UnknownId");
+    Serial.print(F("UnknownId"));
   }
   else {
     Serial.print(data.type, BIN);
   }
-  Serial.print(" ");
+  Serial.print(F(" "));
   Serial.print(data.id);
-  Serial.print(" ");
+  Serial.print(F(" "));
   Serial.print(data.valueHB, HEX);
-  Serial.print(" ");
+  Serial.print(F(" "));
   Serial.print(data.valueLB, HEX);
 }
 


### PR DESCRIPTION
Memory is saved when the strings used for serial communication are stored in flash memory instead of ram. Most Arduino board have a lot more flash then ram.
The F macro ( https://www.arduino.cc/reference/en/language/variables/utilities/progmem/#_the_f_macro ) is used to indicate the compiler to use flash.